### PR TITLE
docs: update active maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,9 +4,8 @@
 
 | name               | Github                                                     | Discord          |
 | ------------------ | ---------------------------------------------------------- | ---------------- |
-| Berend Sliedrecht  | [@blu3beri](https://github.com/blu3beri)                   | blu3beri#2230    |
+| Berend Sliedrecht  | [@berendsliedrecht](https://github.com/berendsliedrecht)   | blu3beri#2230    |
 | Jakub Kočí         | [@jakubkoci](https://github.com/jakubkoci)                 | jakubkoci#1481   |
-| James Ebert        | [@JamesKEbert](https://github.com/JamesKEbert)             | JamesEbert#4350  |
 | Karim Stekelenburg | [@karimStekelenburg](https://github.com/karimStekelenburg) | ssi_karim#3505   |
 | Timo Glastra       | [@TimoGlastra](https://github.com/TimoGlastra)             | TimoGlastra#2988 |
 | Ariel Gentile      | [@genaris](https://github.com/genaris)                     | GenAris#4962     |


### PR DESCRIPTION
This PR contains the following changes to `MAINTAINERS.md`:
- Updated @berendsliedrecht's GitHub handle
    - @berendsliedrecht, I've left your Discord handle untouched as it looks like you didn't update it.
- Removed @JamesKEbert (with approval from James)

Signed-off-by: Karim Stekelenburg <karim@animo.id>
