### PR TITLE
chore: removed jan as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,4 +9,3 @@
 | Karim Stekelenburg | [@karimStekelenburg](https://github.com/karimStekelenburg) | ssi_karim#3505   |
 | Timo Glastra       | [@TimoGlastra](https://github.com/TimoGlastra)             | TimoGlastra#2988 |
 | Ariel Gentile      | [@genaris](https://github.com/genaris)                     | GenAris#4962     |
-| Jan Rietveld       | [@janrtvld](https://github.com/janrtvld)                   | janrtvld#3868    |


### PR DESCRIPTION
Removes @janrtvld (now @janrxyz) from the maintainers. Have coordinated this with him