### PR TITLE
chore: add meta to rxjs timeout errors

### DIFF
--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -898,7 +898,10 @@ export class ConnectionService {
         filterContextCorrelationId(agentContext.contextCorrelationId),
         map((e) => e.payload.connectionRecord),
         first(isConnected), // Do not wait for longer than specified timeout
-        timeout(timeoutMs)
+        timeout({
+          first: timeoutMs,
+          meta: 'ConnectionService.returnWhenIsConnected',
+        })
       )
       .subscribe(subject)
 

--- a/packages/core/src/modules/discover-features/DiscoverFeaturesApi.ts
+++ b/packages/core/src/modules/discover-features/DiscoverFeaturesApi.ts
@@ -121,7 +121,10 @@ export class DiscoverFeaturesApi<
           // Return disclosures
           map((e) => e.payload.disclosures),
           // If we don't have an answer in timeoutMs miliseconds (no response, not supported, etc...) error
-          timeout(options.awaitDisclosuresTimeoutMs ?? 7000), // TODO: Harmonize default timeouts across the framework
+          timeout({
+            first: options.awaitDisclosuresTimeoutMs ?? 7000,
+            meta: 'DiscoverFeaturesApi.queryFeatures',
+          }), // TODO: Harmonize default timeouts across the framework
           // We want to return false if an error occurred
           catchError(() => of([]))
         )

--- a/packages/core/src/modules/oob/OutOfBandApi.ts
+++ b/packages/core/src/modules/oob/OutOfBandApi.ts
@@ -875,7 +875,10 @@ export class OutOfBandApi {
         ),
         // If the event is found, we return the value true
         map(() => true),
-        timeout(15000),
+        timeout({
+          first: 15000,
+          meta: 'OutOfBandApi.handleHandshakeReuse',
+        }),
         // If timeout is reached, we return false
         catchError(() => of(false))
       )

--- a/packages/core/src/modules/routing/MediationRecipientApi.ts
+++ b/packages/core/src/modules/routing/MediationRecipientApi.ts
@@ -428,7 +428,10 @@ export class MediationRecipientApi {
         // Only wait for first event that matches the criteria
         first(),
         // Do not wait for longer than specified timeout
-        timeout(timeoutMs)
+        timeout({
+          first: timeoutMs,
+          meta: 'MediationRecipientApi.requestAndAwaitGrant',
+        })
       )
       .subscribe(subject)
 

--- a/packages/core/src/modules/routing/services/MediationRecipientService.ts
+++ b/packages/core/src/modules/routing/services/MediationRecipientService.ts
@@ -186,7 +186,10 @@ export class MediationRecipientService {
         // Only wait for first event that matches the criteria
         first(),
         // Do not wait for longer than specified timeout
-        timeout(timeoutMs)
+        timeout({
+          first: timeoutMs,
+          meta: 'MediationRecipientService.keylistUpdateAndAwait',
+        })
       )
       .subscribe(subject)
 


### PR DESCRIPTION
This adds a `meta` key to all the meta errors within the framework that contains the class + method name, as it's currently very hard to see where an rxjs timeout error originated.

This will be printed in the error message, and should make debugging easier.

```
TimeoutError: Timeout has occurred
 info: {
  "meta": "<the meta value>",
  "lastValue": null,
  "seen": 0
}
```