### PR TITLE
fix: properly print key class

### DIFF
--- a/packages/core/src/crypto/Key.ts
+++ b/packages/core/src/crypto/Key.ts
@@ -59,4 +59,10 @@ export class Key {
   public get supportsSigning() {
     return isSigningSupportedForKeyType(this.keyType)
   }
+
+  // We return the fingerprint when this object is serialized to JSON
+  // This means it's nicely formatted when printing to the console
+  private toJSON() {
+    return this.fingerprint
+  }
 }

--- a/packages/core/src/crypto/Key.ts
+++ b/packages/core/src/crypto/Key.ts
@@ -60,9 +60,12 @@ export class Key {
     return isSigningSupportedForKeyType(this.keyType)
   }
 
-  // We return the fingerprint when this object is serialized to JSON
-  // This means it's nicely formatted when printing to the console
+  // We return an object structure based on the key, so that when this object is
+  // serialized to JSON it will be nicely formatted instead of the bytes printed
   private toJSON() {
-    return this.fingerprint
+    return {
+      keyType: this.keyType,
+      publicKeyBase58: this.publicKeyBase58,
+    }
   }
 }


### PR DESCRIPTION
This makes sure that at least in the ConsoleLogger the `Key` class is printend as the `fingerprint` property, so we avoid this:

```
{
    "publicKey": {
      "type": "Buffer",
      "data": [
        67,
        227,
        94,
        17,
        202,
        44,
        168,
        217,
        210,
        62,
        120,
        65,
        119,
        12,
        186,
        150,
        210,
        1,
        153,
        142,
        54,
        158,
        119,
        223,
        138,
        189,
        1,
        4,
        72,
        145,
        192,
        23
      ]
    },
    "keyType": "ed25519"
  }
```